### PR TITLE
fix(order) quoted identifiers

### DIFF
--- a/Fase-1/API/self-order-management/src/main/resources/application.yml
+++ b/Fase-1/API/self-order-management/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
             non_contextual_creation: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
         ddl-auto: validate
+        globally_quoted_identifiers: true
 
 self-order:
   admin:


### PR DESCRIPTION
Parece que ["order"](https://www.postgresql.org/docs/current/sql-keywords-appendix.html) é uma palavra reservada do PostgreSQL e para usa-la precisamos escrever o seu nome entre aspas. 